### PR TITLE
unite_test3

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,5 @@
 en:
+  access_denied: "You do not have access"
   activerecord:
     models:
       user: "User"
@@ -400,7 +401,6 @@ devise:
   registrations:
     signed_up: "Welcome %{name} to the system!"
   please_login: "Please login"
-  access_denied: "You do not have access"
   revenue_report:
     title: "Daily Revenue Report"
     greeting: "Dear Admin,"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -56,3 +56,7 @@ request_default_quantity: 1
 request_default_status: "deposited"
 request_token_length: 10
 request_pending_status: "pending"
+reviews_content: "Great stay!"
+reviews_score: 5
+room_type: "Deluxe Room"
+access_denied: "You do not have access"

--- a/spec/controllers/user/reviews_controller_spec.rb
+++ b/spec/controllers/user/reviews_controller_spec.rb
@@ -1,0 +1,108 @@
+require "rails_helper"
+
+RSpec.describe User::ReviewsController, type: :controller do
+  include Devise::Test::ControllerHelpers
+
+  let(:user) { FactoryBot.create(:user) }
+  let(:review) { FactoryBot.build(:review, user: user, score: Settings.reviews_score, content: Settings.reviews_content) }
+
+  before do
+    sign_in user
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+
+  describe "POST #create" do
+    context "with valid parameters" do
+      let(:valid_params) do
+        {
+          review: {
+            score: Settings.reviews_score,
+            content: Settings.reviews_content
+          }
+        }
+      end
+
+      it "creates a new review and redirects" do
+        expect {
+          post :create, params: valid_params
+        }.to change(Review, :count).by(1)
+        expect(response).to redirect_to(user_room_types_path)
+        expect(flash[:success]).to eq(I18n.t("reviews.created"))
+      end
+
+      it "authorizes create action" do
+        expect(controller).to receive(:authorize!).with(:create, instance_of(Review)).at_least(:once)
+        post :create, params: valid_params
+      end
+    end
+
+    context "with invalid parameters" do
+      let(:invalid_params) do
+        {
+          review: {
+            score: nil,
+            content: ""
+          }
+        }
+      end
+
+      it "does not create a review and redirects" do
+        expect {
+          post :create, params: invalid_params
+        }.not_to change(Review, :count)
+        expect(response).to redirect_to(user_room_types_path)
+        expect(flash[:danger]).to eq(I18n.t("reviews.create_failed"))
+      end
+    end
+
+    context "when user is not authenticated" do
+      before do
+        sign_out user
+        post :create, params: { review: { score: Settings.reviews_score, content: Settings.reviews_content } }
+      end
+
+      it "redirects to sign in page" do
+        expect(response.location).to match(/\/user\/sign_in/)
+      end
+    end
+
+    context "without authorization" do
+      before do
+        allow(controller).to receive(:authorize!).and_raise(CanCan::AccessDenied)
+      end
+      
+      it "redirects to root with access denied" do
+        post :create, params: { review: { score: Settings.reviews_score, content: "Nope" }, locale: :en }
+        expect(response).to redirect_to root_path(locale: :en)
+        expect(flash[:danger]).to eq Settings.access_denied
+      end
+      
+    end
+  end
+
+  describe "private methods" do
+    describe "#review_params" do
+      let(:params) do
+        ActionController::Parameters.new(
+          review: {
+            score: Settings.reviews_score,
+            content: Settings.reviews_content,
+            unauthorized_field: "malicious"
+          }
+        )
+      end
+
+      before do
+        allow(controller).to receive(:params).and_return(params)
+      end
+
+      it "permits only score and content from REVIEW_PARAMS" do
+        expect(controller.send(:review_params)).to eq(
+          ActionController::Parameters.new(score: Settings.reviews_score, content: Settings.reviews_content).permit(:score, :content)
+        )
+      end
+    end
+  end
+end
+
+

--- a/spec/factories/review.rb
+++ b/spec/factories/review.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+    factory :review do
+      user
+      score { Settings.reviews_score }
+      content { Settings.reviews_content}
+    end
+  end


### PR DESCRIPTION
## Related Tickets
- [#86673](https://edu-redmine.sun-asterisk.vn/issues/88484?issue_count=10&issue_position=1&next_issue_id=86673)

## WHAT (optional)
- Change number items `completed/total` in admin page.

## HOW
- I edit js file, inject not_vary_normal items in calculate function.

## WHY (optional)
- Because in previous version - number just depends on `normal` items. But in new version, we have `state` and `confirm_state` depends on both `normal` + `not_normal` items.

## Evidence (Screenshot or Video)
![image](https://github.com/user-attachments/assets/66fadb43-f2a9-4464-b80f-9dc97c5f3ae4)
